### PR TITLE
improvement: deprecation fix

### DIFF
--- a/admin/class-qplugin-wc-payment-gateway.php
+++ b/admin/class-qplugin-wc-payment-gateway.php
@@ -196,7 +196,7 @@ if (!class_exists('WC_QPlugin_Gateway')) {
       $order = wc_get_order($order_id);
 
       // Reduce stock levels
-      $order->reduce_order_stock();
+      wc_reduce_stock_levels($order_id);
 
       // Remove cart
       $woocommerce->cart->empty_cart();


### PR DESCRIPTION
 *  [WC_Order::reduce_order_stock](https://wp-kama.com/plugin/woocommerce/function/WC_Abstract_Legacy_Order::reduce_order_stock) function replaced with "wc_reduce_stock_levels"
